### PR TITLE
Fix CSV ordering bug

### DIFF
--- a/backend-node/server.js
+++ b/backend-node/server.js
@@ -42,7 +42,15 @@ async function writeCSV(filePath, dataArray) {
       return;
     }
     const header = 'value,order_index\n';
-    const rows = dataArray.map((obj, index) => `${obj.value},${obj.order_index || index}`).join('\n');
+    const rows = dataArray
+      .map((obj, index) => {
+        const orderIndex =
+          obj.order_index !== undefined && obj.order_index !== null
+            ? obj.order_index
+            : index;
+        return `${obj.value},${orderIndex}`;
+      })
+      .join('\n');
     await fs.writeFile(filePath, header + rows);
   } catch (err) {
     throw new Error(`Failed to write CSV file: ${err.message}`);


### PR DESCRIPTION
## Summary
- prevent Node.js backend from overwriting order_index when value is `0`

## Testing
- `npm install`
- `node -c backend-node/server.js`

------
https://chatgpt.com/codex/tasks/task_e_683f69924770832dbfce2111220e7c2c